### PR TITLE
Support XMSS hash-based signature aggregation

### DIFF
--- a/src/hash_tree.rs
+++ b/src/hash_tree.rs
@@ -1,0 +1,147 @@
+use crate::{Hash, Param, hash::tweak_hash_tree_node};
+
+pub struct HashTree {
+    /// The hash nodes in each level of the tree.
+    ///
+    /// - `levels[0]` contains all leaf nodes (bottom level)
+    /// - `levels[levels.len() - 1]` contains the single root node (top level)
+    ///
+    /// Within each level, nodes are ordered left-to-right. For example,
+    /// `levels[l][2i]` and `levels[l][2i + 1]` are hashed together to produce `levels[l + 1][i]`.
+    pub levels: Vec<Vec<Hash>>,
+
+    /// The root hash of the Hash tree.
+    ///
+    /// This is equal to `levels[levels.len() - 1][0]`.
+    pub root: Hash,
+}
+
+impl HashTree {
+    /// Constructs a new Hash tree from a vector of leaf nodes.
+    ///
+    /// It uses the hash crate::hash::tweak_hash_tree_node
+    ///
+    /// # Arguments
+    ///
+    /// * `param` - Cryptographic parameters for the hash function
+    /// * `leaves` - Vector of leaf hashes (must be a power of 2 in length)
+    ///
+    /// # Returns
+    ///
+    /// A `HashTree` containing all intermediate nodes organized by level
+    /// and the computed root hash.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of leaves is not a power of 2.
+    pub fn new(param: &Param, leaves: Vec<Hash>) -> Self {
+        let num_leaves = leaves.len();
+        assert!(
+            num_leaves.is_power_of_two(),
+            "Number of leaves must be a power of 2"
+        );
+
+        let height = num_leaves.ilog2() as usize;
+        let mut levels = vec![leaves];
+
+        for current_level_idx in 0..height {
+            let parent_nodes = levels[current_level_idx]
+                .chunks_exact(2)
+                .enumerate()
+                .map(|(i, pair)| {
+                    tweak_hash_tree_node(
+                        param,
+                        &pair[0],
+                        &pair[1],
+                        current_level_idx as u32,
+                        i as u32,
+                    )
+                })
+                .collect();
+            levels.push(parent_nodes);
+        }
+
+        let root = levels[height][0];
+
+        Self { levels, root }
+    }
+
+    /// Generates a Hash proof for a leaf at the given index.
+    ///
+    /// The proof consists of sibling hashes at each level needed to reconstruct
+    /// the path from the leaf to the root. When verifying, these siblings are
+    /// hashed with intermediate values to recompute the root.
+    ///
+    /// # Arguments
+    ///
+    /// * `leaf_index` - The index of the leaf to prove
+    ///
+    /// # Returns
+    ///
+    /// A `HashTreeProof` containing:
+    /// - The original leaf index
+    /// - Authentication path: sibling hashes from leaf level to just below root
+    pub fn get_proof(&self, leaf_index: usize) -> HashTreeProof {
+        let mut path = Vec::new();
+        let mut index = leaf_index;
+
+        for level in &self.levels[..self.levels.len() - 1] {
+            // Siblings appear in pairs at indices (2i, 2i + 1)
+            // so we can find the index of a sibling by flipping
+            // the least-significant bit.
+            let sibling_index = index ^ 1;
+            path.push(level[sibling_index]);
+            // The parent index for siblings (2i, 2i + 1) is i
+            index /= 2;
+        }
+
+        HashTreeProof { leaf_index, path }
+    }
+}
+
+#[derive(Clone)]
+pub struct HashTreeProof {
+    leaf_index: usize,
+    path: Vec<Hash>,
+}
+
+impl HashTreeProof {
+    /// Verifies that a leaf value belongs to a Hash tree with the given root.
+    ///
+    /// Reconstructs the path from leaf to root by iteratively hashing the
+    /// current value with siblings from the path. The proof is valid if the
+    /// computed root matches the expected root.
+    ///
+    /// # Arguments
+    ///
+    /// * `param` - Cryptographic parameters for the hash function
+    /// * `leaf` - The leaf hash value to verify
+    /// * `root` - The expected root hash of the Hash tree
+    ///
+    /// # Returns
+    ///
+    /// `true` if the proof is valid (computed root matches expected root), `false` otherwise
+    pub fn verify(&self, param: &Param, leaf: &Hash, root: &Hash) -> bool {
+        let mut current_hash = *leaf;
+        let mut index = self.leaf_index;
+
+        for (level, &sibling_hash) in self.path.iter().enumerate() {
+            // Siblings appear in pairs at indices (2i, 2i + 1)
+            // So we can determine the order of siblings by comparing the
+            // least significant bit
+            let (left, right) = if index & 1 == 0 {
+                (current_hash, sibling_hash)
+            } else {
+                (sibling_hash, current_hash)
+            };
+
+            // The parent index for siblings (2i, 2i + 1) is i
+            let parent_index = index / 2;
+
+            current_hash =
+                tweak_hash_tree_node(param, &left, &right, level as u32, parent_index as u32);
+            index = parent_index;
+        }
+        current_hash == *root
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,13 @@ use rand::{RngCore, rngs::StdRng};
 use spec::Spec;
 
 use crate::hash::Hash;
+use crate::hash::tweak_public_key_hash;
+use crate::hash_tree::{HashTree, HashTreeProof};
 
 mod code;
 mod hash;
 mod hash_chain;
+mod hash_tree;
 
 pub mod spec;
 
@@ -105,42 +108,86 @@ impl Sk {
 }
 
 #[derive(Clone)]
-pub struct Signature {
+pub struct OtsSignature {
     nonce: Nonce,
     hashes: Vec<Hash>,
 }
 
+#[derive(Clone)]
+pub struct Signature {
+    /// The one-time signature
+    pub signature: OtsSignature,
+    /// Proof that the public-key associated to the epoch is present in the XMSS
+    /// hash tree
+    pub hash_tree_proof: HashTreeProof,
+    /// The public key used for this signature
+    pub public_key: Pk,
+}
+
 pub struct Signer {
     rng: StdRng,
-    /// The number of times we try to grind the message.
     max_retries: usize,
-    /// The specification for this signature scheme.
-    spec: Spec,
+    /// The specification defining the signature scheme parameters (chain length, dimensions, etc.)
+    pub spec: Spec,
+    /// The public parameter shared across all signatures from this signer
+    pub param: Param,
+    hash_tree: HashTree,
+    key_pairs: Vec<(Sk, Pk)>,
+    /// The root hash of the XMSS Merkle tree, serving as the public commitment to all one-time keys
+    pub root: Hash,
 }
 
 impl Signer {
-    pub fn new(rng: StdRng, max_retries: usize, spec: Spec) -> Self {
+    /// Create a new XMSS signer with multiple one-time key pairs
+    ///
+    /// # Arguments
+    /// * `rng` - Random number generator for key generation
+    /// * `max_retries` - Maximum attempts to find a valid signature (for grinding the nonce)
+    /// * `spec` - The specification defining the signature scheme parameters
+    /// * `lifetime` - Number of one-time signatures this signer can produce (number of epochs)
+    ///
+    /// # Returns
+    /// A new `Signer` with `lifetime` key pairs and a Merkle tree commitment
+    pub fn new(mut rng: StdRng, max_retries: usize, spec: Spec, lifetime: usize) -> Self {
+        let param = Param::random(spec.param_len, &mut rng);
+
+        let mut key_pairs = Vec::new();
+        for _ in 0..lifetime {
+            let sk = Sk::random(&mut rng, param.clone(), &spec);
+            let pk = Pk::derive(&sk, &spec);
+            key_pairs.push((sk, pk));
+        }
+
+        let pub_key_hashes: Vec<_> = key_pairs
+            .iter()
+            .map(|(_, pk)| tweak_public_key_hash(&param, pk))
+            .collect();
+
+        let hash_tree = HashTree::new(&param, pub_key_hashes);
+        let root = hash_tree.root.clone();
+
         Self {
             rng,
             max_retries,
             spec,
+            hash_tree,
+            key_pairs,
+            param,
+            root,
         }
     }
 
-    /// Generate a random key pair.
-    pub fn gen_pair(&mut self) -> (Sk, Pk) {
-        let param = Param::random(self.spec.param_len, &mut self.rng);
-        let sk = Sk::random(&mut self.rng, param.clone(), &self.spec);
-        let pk = Pk::derive(&sk, &self.spec);
-        (sk, pk)
-    }
-
-    /// Sign the given message with a secret key and produce a signature.
+    /// Sign a message using the key at the given epoch
     ///
-    /// In some unlikely cases we may fail to produce a signature. The probability of that is
-    /// inversely proportional to the number of retries.
-    pub fn sign(&mut self, sk: &Sk, message: &Message) -> Option<Signature> {
-        let (codeword, rho) = code::grind(
+    /// Returns None if the signer could not produce a Signature
+    pub fn sign(&mut self, epoch: usize, message: &Message) -> Option<Signature> {
+        assert!(
+            epoch < self.key_pairs.len(),
+            "epoch must be less than the total number of keys"
+        );
+        let (sk, pk) = &self.key_pairs[epoch];
+
+        let (codeword, nonce) = code::grind(
             &self.spec,
             self.max_retries,
             &sk.param,
@@ -159,64 +206,270 @@ impl Signer {
             })
             .collect();
 
-        Some(Signature { nonce: rho, hashes })
+        let signature = OtsSignature { nonce, hashes };
+        let hash_tree_proof = self.hash_tree.get_proof(epoch);
+        let public_key = pk.clone();
+
+        Some(Signature {
+            signature,
+            hash_tree_proof,
+            public_key,
+        })
+    }
+}
+
+/// Verify an XMSS signature with HashTree proof
+///
+/// The verification procedure consists of two main steps:
+///
+/// 1. **One-Time Signature (OTS) Verification**:
+///    - Reconstruct the codeword from the message and nonce
+///    - Use the codeword coordinates to determine positions in hash chains
+///    - Complete the hash chains from the provided intermediate hashes
+///    - Compare the computed end hashes with the public key's end hashes
+///
+/// 2. **Merkle Tree Proof Verification**:
+///    - Hash the public key to get the leaf value
+///    - Verify the proof path from leaf to the committed root
+///    - Ensure the public key is indeed part of the XMSS tree
+///
+/// # Arguments
+/// * `spec` - The specification for the signature scheme
+/// * `param` - The parameter used by the signer
+/// * `message` - The message that was signed
+/// * `signature` - The XMSS signature with hash tree proof and public key
+/// * `root` - The root hash of the XMSS tree to verify against
+///
+/// # Returns
+/// `true` if both the OTS signature and tree proof are valid, `false` otherwise
+pub fn verify_signature(
+    spec: &Spec,
+    param: &Param,
+    message: &Message,
+    signature: &Signature,
+    root: &Hash,
+) -> bool {
+    // Use the public key from the signature for verification
+    let pk = &signature.public_key;
+
+    // Step 1: Verify the one-time signature
+    // First, reconstruct the codeword from the message and nonce
+    let Some(codeword) = code::new_valid(spec, &pk.param, message, &signature.signature.nonce)
+    else {
+        // The message + nonce combination doesn't produce a valid codeword
+        // This means the signature is invalid
+        return false;
+    };
+    assert_eq!(codeword.dimension(), spec.dimension());
+
+    // The codeword tells us positions in each hash chain
+    // We need to complete the hash chains from those positions to the end
+    let chain_len = spec.chain_len();
+    let hashes = signature.signature.hashes.iter();
+    let coords = codeword.coords().iter().map(|&coord| coord as usize);
+
+    // For each chain, compute from the given hash at position `hash_pos`
+    // to the end of the chain (position chain_len - 1)
+    let end_hashes = hashes
+        .zip(coords)
+        .enumerate()
+        .map(|(chain_index, (hash, hash_pos))| {
+            hash_chain(
+                &pk.param,
+                chain_index,
+                *hash,
+                hash_pos,                 // Current position in chain
+                chain_len - 1 - hash_pos, // Steps remaining to end
+            )
+        });
+
+    // Compare computed end hashes with the public key's end hashes
+    // If they don't match, the OTS signature is invalid
+    if !end_hashes.eq(pk.end_hashes.iter().cloned()) {
+        return false;
     }
 
-    /// Verify a signature.
+    // Step 2: Verify the Merkle tree proof
+    // This proves that the public key used above is part of the XMSS tree
+    let leaf_hash = tweak_public_key_hash(param, pk);
+    signature.hash_tree_proof.verify(param, &leaf_hash, root)
+}
+
+/// A signature from a single validator
+#[derive(Clone)]
+pub struct ValidatorSignature {
+    /// The epoch used for signing
+    pub epoch: usize,
+    /// The XMSS signature
+    pub signature: Signature,
+    /// The root hash this signature should verify against
+    pub xmss_root: Hash,
+    /// The parameter used by this validator
+    pub param: Param,
+}
+
+/// Aggregated signatures from multiple validators
+pub struct AggregatedSignature {
+    /// Individual signatures from each validator
+    pub signatures: Vec<ValidatorSignature>,
+}
+
+impl AggregatedSignature {
+    /// Create a new aggregated signature from a list of validator signatures
+    pub fn new(signatures: Vec<ValidatorSignature>) -> Self {
+        Self { signatures }
+    }
+}
+
+/// A collection of validator root hashes for verification
+pub struct AggregatedVerifier {
+    /// List of registered validator roots
+    roots: Vec<Hash>,
+    /// The specification for the signature scheme
+    spec: Spec,
+}
+
+impl AggregatedVerifier {
+    /// Create a new validator roots collection
+    pub fn new(roots: Vec<Hash>, spec: Spec) -> Self {
+        Self { roots, spec }
+    }
+
+    /// Verify an aggregated signature from multiple validators
     ///
-    /// Given the public key, signature and the message, returns whether the signature was plausibly
-    /// generated by the private key corresponding to the public key.
-    pub fn verify(&self, pk: &Pk, signature: &Signature, message: &Message) -> bool {
-        let Some(codeword) = code::new_valid(&self.spec, &pk.param, message, &signature.nonce)
-        else {
-            // The specified message combined with `nonce` does not provide a valid codeword.
-            return false;
-        };
-        assert_eq!(codeword.dimension(), self.spec.dimension());
-
-        let chain_len = self.spec.chain_len();
-        let hashes = signature.hashes.iter();
-        let coords = codeword.coords().iter().map(|&coord| coord as usize);
-        let end_hashes = hashes
-            .zip(coords)
-            .enumerate()
-            .map(|(chain_index, (hash, hash_pos))| {
-                hash_chain(
-                    &pk.param,
-                    chain_index,
-                    *hash,
-                    hash_pos,
-                    chain_len - 1 - hash_pos,
+    /// Returns `true` if all signatures are valid and from registered validators,
+    /// `false` otherwise
+    pub fn verify(&self, message: &Message, aggregated: &AggregatedSignature) -> bool {
+        aggregated.signatures.iter().all(|sig| {
+            // Check if this signature's root is in our validator set
+            self.roots.contains(&sig.xmss_root) &&
+                // Verify using the param from the ValidatorSignature
+                verify_signature(
+                    &self.spec,
+                    &sig.param,
+                    message,
+                    &sig.signature,
+                    &sig.xmss_root,
                 )
-            });
-
-        end_hashes.eq(pk.end_hashes.iter().cloned())
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::spec::Spec;
-
     use super::*;
     use rand::SeedableRng;
-    fn sign(spec: Spec) {
-        let mut signer = Signer::new(StdRng::from_os_rng(), 1000000, spec);
-        let (sk, pk) = signer.gen_pair();
-        let message = Message([1; 32]);
-        let Some(signature) = signer.sign(&sk, &message) else {
-            panic!("Failed to sign");
-        };
-        assert!(signer.verify(&pk, &signature, &message));
+
+    #[test]
+    fn test_xmss_verify() {
+        let spec = spec::SPEC_2;
+        let mut signer = Signer::new(StdRng::seed_from_u64(0), 1000000, spec.clone(), 8);
+
+        // Get public verification parameters
+        let root = signer.root.clone();
+        let param = signer.param.clone();
+
+        let message1 = Message([10; 32]);
+        let message2 = Message([20; 32]);
+        let bad_message = Message([30; 32]);
+
+        let sig1 = signer
+            .sign(0, &message1)
+            .expect("Failed to sign with epoch 0");
+        let sig3 = signer
+            .sign(3, &message2)
+            .expect("Failed to sign with epoch 3");
+
+        assert!(verify_signature(&spec, &param, &message1, &sig1, &root));
+        assert!(verify_signature(&spec, &param, &message2, &sig3, &root));
+
+        assert!(!verify_signature(&spec, &param, &bad_message, &sig1, &root));
+        assert!(!verify_signature(&spec, &param, &message2, &sig1, &root));
+        assert!(!verify_signature(&spec, &param, &message1, &sig3, &root));
     }
 
     #[test]
-    fn test_spec_1() {
-        sign(spec::SPEC_1);
-    }
+    fn test_aggregated_signatures() {
+        let spec = spec::SPEC_2;
 
-    #[test]
-    fn test_spec_2() {
-        sign(spec::SPEC_2);
+        // Create multiple validators (each with their own param)
+        let mut validator1 = Signer::new(StdRng::seed_from_u64(1), 10000, spec.clone(), 4);
+        let mut validator2 = Signer::new(StdRng::seed_from_u64(2), 10000, spec.clone(), 4);
+        let mut validator3 = Signer::new(StdRng::seed_from_u64(3), 10000, spec.clone(), 4);
+
+        // Register validator roots
+        let roots = vec![
+            validator1.root.clone(),
+            validator2.root.clone(),
+            validator3.root.clone(),
+        ];
+
+        // Create the validator roots collection for verification
+        let verifier = AggregatedVerifier::new(roots, spec);
+
+        // Message to be signed by all validators
+        let message = Message([42; 32]);
+
+        // Each validator signs the message
+        let sig1 = validator1.sign(0, &message).expect("Failed to sign");
+        let sig2 = validator2.sign(0, &message).expect("Failed to sign");
+        let sig3 = validator3.sign(0, &message).expect("Failed to sign");
+
+        // Create aggregated signature
+        let aggregated = AggregatedSignature::new(vec![
+            ValidatorSignature {
+                epoch: 0,
+                signature: sig1,
+                xmss_root: validator1.root.clone(),
+                param: validator1.param.clone(),
+            },
+            ValidatorSignature {
+                epoch: 0,
+                signature: sig2,
+                xmss_root: validator2.root.clone(),
+                param: validator2.param.clone(),
+            },
+            ValidatorSignature {
+                epoch: 0,
+                signature: sig3,
+                xmss_root: validator3.root.clone(),
+                param: validator3.param.clone(),
+            },
+        ]);
+
+        // Verify the aggregated signature (all should be valid)
+        assert!(verifier.verify(&message, &aggregated));
+
+        // Test with only 2 signatures
+        let partial_aggregated = AggregatedSignature::new(vec![
+            ValidatorSignature {
+                epoch: 0,
+                signature: validator1.sign(1, &message).expect("Failed to sign"),
+                xmss_root: validator1.root.clone(),
+                param: validator1.param.clone(),
+            },
+            ValidatorSignature {
+                epoch: 0,
+                signature: validator2.sign(1, &message).expect("Failed to sign"),
+                xmss_root: validator2.root.clone(),
+                param: validator2.param.clone(),
+            },
+        ]);
+
+        // Both signatures should be valid
+        assert!(verifier.verify(&message, &partial_aggregated));
+
+        // Test with invalid signature
+        let bad_message = Message([99; 32]);
+        let bad_sig = validator1.sign(2, &bad_message).expect("Failed to sign");
+        let invalid_aggregated = AggregatedSignature::new(vec![ValidatorSignature {
+            epoch: 2,
+            signature: bad_sig,
+            xmss_root: validator1.root.clone(),
+            param: validator1.param.clone(),
+        }]);
+
+        // Should fail because signature is for wrong message
+        assert!(!verifier.verify(&message, &invalid_aggregated));
     }
 }


### PR DESCRIPTION
This PR updates the Signer with an implementation of XMSS to support many-time
signatures using the underlying one-time signature Winternitz scheme.

A Signer uses a HashTree to commit to a sequence of public keys, one
for each slot / epoch.

Several signatures of a common message can be aggregated and verified
together.