### PR TITLE
Use tiny-keccak instead of sha2 for hashes

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 bitvec = "1.0.1"
 hex-literal = "1.0.0"
 rand = "0.9.2"
-sha2 = "0.10.9"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }


### PR DESCRIPTION
The native rust implementation must use keccak to match the hash we're using in the binius64 circuit.

`tiny-keccak` is used instead of the standard `sha3` crate because RISC0 publishes a precompile keccak based on tiny-keccak:

https://dev.risczero.com/api/zkvm/precompiles#stability