### PR TITLE
Use explicit u64 in chain tweak because usize is u32 in RISC0

### DIFF
--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -50,8 +50,8 @@ pub fn tweak_hash_chain(
     hasher.update(param.as_ref());
     hasher.update(&[TWEAK_CHAIN]);
     hasher.update(hash.as_ref());
-    hasher.update(&chain_index.to_be_bytes());
-    hasher.update(&pos_in_chain.to_be_bytes());
+    hasher.update(&(chain_index as u64).to_be_bytes());
+    hasher.update(&(pos_in_chain as u64).to_be_bytes());
     let mut result = [0u8; 32];
     hasher.finalize(&mut result);
     Hash(result)


### PR DESCRIPTION
RISC0's usize is 32bit so we must use explicit u64 in the chain hash tweak to make sure the same hashes are computed in the host (signing) and guest (verification).