### PR TITLE
Make leansig-core type serializable

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 bitvec = "1.0.1"
 hex-literal = "1.0.0"
 rand = "0.9.2"
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -1,6 +1,7 @@
 //! Definition of various tweaked hash functions used in the project.
 
 use rand::{RngCore as _, rngs::StdRng};
+use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Keccak};
 
 use crate::{Message, Nonce, Param, Pk};
@@ -11,7 +12,7 @@ const TWEAK_CHAIN: u8 = 0x00;
 const TWEAK_TREE: u8 = 0x01;
 const TWEAK_MESSAGE: u8 = 0x02;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Hash(pub [u8; 32]);
 
 impl Hash {

--- a/crates/core/src/hash_tree.rs
+++ b/crates/core/src/hash_tree.rs
@@ -1,4 +1,5 @@
 use crate::{Hash, Param, hash::tweak_hash_tree_node};
+use serde::{Deserialize, Serialize};
 
 pub struct HashTree {
     /// The hash nodes in each level of the tree.
@@ -99,10 +100,10 @@ impl HashTree {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HashTreeProof {
     leaf_index: usize,
-    path: Vec<Hash>,
+    pub path: Vec<Hash>,
 }
 
 impl HashTreeProof {

--- a/crates/core/src/spec.rs
+++ b/crates/core/src/spec.rs
@@ -1,5 +1,7 @@
+use serde::{Deserialize, Serialize};
+
 /// Specification for the signature scheme instantiation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Spec {
     pub message_hash_len: usize,
     /// The number of bits per each coordinate in a codeword.


### PR DESCRIPTION
We must pass signatures etc. from the RISC0 host to the guest. This is done via serde serialisation, so we must make the rust types Serializable / Deserializable.